### PR TITLE
fix: removes duplicate Page nodes appearing when adding a MenuItem

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 
 Unreleased
 ==========
+* fix: Remove duplicate objects when adding MenuItem nodes
+* feat: When adding a MenuItem the Page objects are filtered for the current site and language
 
 1.5.0 (2022-08-22)
 ==================

--- a/djangocms_navigation/cms_config.py
+++ b/djangocms_navigation/cms_config.py
@@ -93,7 +93,7 @@ class NavigationCMSAppConfig(CMSAppConfig):
     )
     navigation_models = {
         # model_class : field(s) to search in menu item form UI
-        Page: ["title"]
+        Page: ["pagecontent_set__title__icontains"]
     }
     djangocms_references_enabled = True
     reference_fields = [

--- a/tests/test_cms_config.py
+++ b/tests/test_cms_config.py
@@ -75,7 +75,7 @@ class NavigationIntegrationTestCase(TestCase):
             TestModel2: [],
             TestModel3: [],
             TestModel4: [],
-            Page: ["title"],
+            Page: ["pagecontent_set__title__icontains"],
             PollContent: ["text"],
         }
         self.assertDictEqual(registered_models, expected_models)


### PR DESCRIPTION
Previously duplicate Page objects would appear in the Content Object
selection list, which would occur after the queryset of objects is
filtered by the title. It was possible this would also affect other
content types, if the filter was across related objects. To avoid this,
adds a distinct() call to the queryset before it is returned if we have
a query to filter by. Adds tests which would previously have failed
without the change to add distinct().

fix: refactor get_data method to improve readability

Removes number of nested conditionals by returning early when possible

fix: flake8 and isort fixes

fix: refactor tests to allow better unit tests for get_data method

- add unit tests to check search_fields filtering
- add unit tests for filtering Page QuerySet by title

fix: changelog

fix: cleanup test docstrings

feature: filter Page objects by language when adding a MenuItem node

feat: filter page by site when adding menu items

Implements filter by site when adding a page as a menu item.
Updates the NavigationCMSAppConfig to set the page filter field there
to allow the hardcoded filter query to be removed from the view.

feat: integration test for filter by language

feat: add integration test for pages for multiple sites

feat: update changelog

fix: site filter test docstring and assert